### PR TITLE
feat: Support for User Parts Lists

### DIFF
--- a/pypartpicker/regex.py
+++ b/pypartpicker/regex.py
@@ -2,10 +2,10 @@ import re
 
 
 def get_list_links(string):
-    list_regex = re.compile("((?:http|https)://(?:[a-z]{2}.pcpartpicker|pcpartpicker).com/list/(?:[a-zA-Z0-9]{6}))")
+    list_regex = re.compile("((?:http|https)://(?:[a-z]{2}.)?pcpartpicker.com/(?:(?:list/(?:[a-zA-Z0-9]{6}))|(?:user/(?:[\\w]+)/saved/(?:[a-zA-Z0-9]{6}))))")
     return re.findall(list_regex, string)
 
 
 def get_product_links(string):
-    product_regex = re.compile("((?:http|https)://(?:[a-z]{2}.pcpartpicker|pcpartpicker).com/product/(?:[a-zA-Z0-9]{6}))")
+    product_regex = re.compile("((?:http|https)://(?:[a-z]{2}.)?pcpartpicker.com/product/(?:[a-zA-Z0-9]{6}))")
     return re.findall(product_regex, string)


### PR DESCRIPTION
This PR addresses issue #7, fixes some bugs with the asynchronous functions and makes some very minor fixes to code formatting.

---

First and foremost is adding the support for parts lists that exist under the `https://pcpartpicker.com/user/username/saved/` URL. Behind the scenes, these parts lists are effectively the same as the ones that the API currently supports (`https://pcpartpicker.com/list/`), so it was merely a matter of updating the logic that determined the validity of a URL.

The RegEx used in the `get_list_links()` function (pypartpicker/regex.py) has been modified to match `pcpartpicker.com/list/code` OR `pcpartpicker.com/user/username/code`. Since usernames are of variable length, I used the following non-capture group `(?:[\\w]+)` which matches a string that contains at least one alphanumeric (including underscore) character (the `+` quantifier is what enables this variable length behaviour).

I also cleaned up the RegEx that checked for the country subdomain in both the `get_list_links()` and `get_product_links()` functions. So rather than having a conditional that checks for `country.pcpartpicker` OR `pcpartpicker`, instead I've opted to check for only `country.pcpartpicker` but with `country.` being defined as an optional field (using `?`).

---

Next was actually updating pypartpicker/Scraper.py so that it would accept `/user/` URLs. I noticed that in the following lines you opted *not* to use any form of RegEx even though you already had two functions that could check for the same thing.

https://github.com/QuaKe8782/pypartpicker/blob/2fadced708ef1b6201a7cd4dbc7747b950c7e5c1/pypartpicker/scraper.py#L86

https://github.com/QuaKe8782/pypartpicker/blob/2fadced708ef1b6201a7cd4dbc7747b950c7e5c1/pypartpicker/scraper.py#L236

My proposed implementation adds two new [private methods](https://www.geeksforgeeks.org/private-methods-in-python/): `__check_list_url()` and `__check_product_url()` which utilize the updated RegEx from earlier. If the URL string that was passed to the `fetch_list()` or `fetch_product()` methods is of the desired format, then the corresponding private method will return **True** (and your if statement will be skipped over). It doesn't really get much simpler/elegant than that in my opinion.

---

Some other notable changes worth mentioning:
* The three asynchronous methods all had a **serious bug that prevented them from executing**. A `TypeError` was being thrown due to not passing `self` as a parameter in the method signature (when within the method you were calling methods from the class). I don't mean to sound arrogant, but this is something that you would have easily caught had you actually [tested](https://medium.com/@AgariInc/strategies-for-testing-async-code-in-python-c52163f2deab) the methods before committing.
* The `make_soup()` method has been converted to a private method (under the assumption that it is just a helper method that a user shouldn't be able to access/call on their own outside of the Scraper class).
* Updated all calls to the `make_soup()` method to account for the above change.
* Raise a [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError) instead of a bare Exception when `fetch_list()` detects an invalid PCPP list URL (since this has to do with invalid user input).
* Fixed line spacing between classes & methods
* Converted use of `!=` in conditionals to more proper `is not`
