### PR TITLE
Fix user list regex

### DIFF
--- a/pypartpicker/regex.py
+++ b/pypartpicker/regex.py
@@ -2,7 +2,7 @@ import re
 
 
 def get_list_links(string):
-    list_regex = re.compile("((?:http|https)://(?:[a-z]{2}.)?pcpartpicker.com/(?:(?:list/(?:[a-zA-Z0-9]{6}))|(?:user/(?:[\\w]+)/saved/(?:[a-zA-Z0-9]{6}))))")
+    list_regex = re.compile("((?:http|https)://(?:[a-z]{2}.)?pcpartpicker.com/(?:(?:list/(?:[a-zA-Z0-9]{6}))|(?:user/(?:[\w]+)/saved/(?:[a-zA-Z0-9]{6}))))")
     return re.findall(list_regex, string)
 
 

--- a/pypartpicker/regex.py
+++ b/pypartpicker/regex.py
@@ -1,11 +1,12 @@
 import re
 
+LIST_REGEX = re.compile("((?:http|https)://(?:[a-z]{2}.)?pcpartpicker.com/(?:(?:list/(?:[a-zA-Z0-9]{6}))|(?:user/(?:[\\w]+)/saved/(?:[a-zA-Z0-9]{6}))))")
+PRODUCT_REGEX = re.compile("((?:http|https)://(?:[a-z]{2}.)?pcpartpicker.com/product/(?:[a-zA-Z0-9]{6}))")
+
 
 def get_list_links(string):
-    list_regex = re.compile("((?:http|https)://(?:[a-z]{2}.)?pcpartpicker.com/(?:(?:list/(?:[a-zA-Z0-9]{6}))|(?:user/(?:[\w]+)/saved/(?:[a-zA-Z0-9]{6}))))")
-    return re.findall(list_regex, string)
+    return re.findall(LIST_REGEX, string)
 
 
 def get_product_links(string):
-    product_regex = re.compile("((?:http|https)://(?:[a-z]{2}.)?pcpartpicker.com/product/(?:[a-zA-Z0-9]{6}))")
-    return re.findall(product_regex, string)
+    return re.findall(PRODUCT_REGEX, string)

--- a/pypartpicker/scraper.py
+++ b/pypartpicker/scraper.py
@@ -89,7 +89,7 @@ class Scraper:
     # Private Helper Function
     # Uses a RegEx to check if the specified string matches the URL format of a valid PCPP parts list
     def __check_list_url(self, url_str):
-        return re.search(r"((?:http|https)://(?:[a-z]{2}.)?pcpartpicker.com/(?:(?:list/(?:[a-zA-Z0-9]{6}))|(?:user/(?:[\\w]+)/saved/(?:[a-zA-Z0-9]{6}))))", url_str)
+        return re.search(r"((?:http|https)://(?:[a-z]{2}.)?pcpartpicker.com/(?:(?:list/(?:[a-zA-Z0-9]{6}))|(?:user/(?:[\w]+)/saved/(?:[a-zA-Z0-9]{6}))))", url_str)
 
     # Private Helper Function
     # Uses a RegEx to check if the specified string matches the URL format of a valid product on PCPP

--- a/pypartpicker/scraper.py
+++ b/pypartpicker/scraper.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import math
 import re
 import requests
+from pypartpicker.regex import LIST_REGEX, PRODUCT_REGEX
 
 from bs4 import BeautifulSoup
 from functools import partial
@@ -89,12 +90,12 @@ class Scraper:
     # Private Helper Function
     # Uses a RegEx to check if the specified string matches the URL format of a valid PCPP parts list
     def __check_list_url(self, url_str):
-        return re.search(r"((?:http|https)://(?:[a-z]{2}.)?pcpartpicker.com/(?:(?:list/(?:[a-zA-Z0-9]{6}))|(?:user/(?:[\w]+)/saved/(?:[a-zA-Z0-9]{6}))))", url_str)
+        return re.search(LIST_REGEX, url_str)
 
     # Private Helper Function
     # Uses a RegEx to check if the specified string matches the URL format of a valid product on PCPP
     def __check_product_url(self, url_str):
-        return re.search(r"((?:http|https)://(?:[a-z]{2}.)?pcpartpicker.com/product/(?:[a-zA-Z0-9]{6}))", url_str)
+        return re.search(PRODUCT_REGEX, url_str)
 
     def fetch_list(self, list_url) -> PCPPList:
         # Ensure a valid pcpartpicker parts list was passed to the function


### PR DESCRIPTION
Currently the regex in `__check_list_url` is expecting a URL like `https://pcpartpicker.com/user/\w/saved/abC123` (the exact string `\w` instead of the regex match statement)

Bizarrely the compiled regex in `regex.py` works fine though - originally I removed the additional `\`, however made a bit more sense to use the same pre-compiled regex everywhere (removes a bit of duplication)