### PR TITLE
Correct the return type of part_search

### DIFF
--- a/pypartpicker/scraper.py
+++ b/pypartpicker/scraper.py
@@ -197,7 +197,7 @@ class Scraper:
             compatibility=compatibilitynotes,
         )
 
-    def part_search(self, search_term, **kwargs) -> Part:
+    def part_search(self, search_term, **kwargs) -> list[Part]:
         search_term = search_term.replace(" ", "+")
         limit = kwargs.get("limit", 20)
 


### PR DESCRIPTION
Unless I'm mistaken, `part_search` always returns a list of parts, never a part by itself.